### PR TITLE
Fix add dish

### DIFF
--- a/components/DishForm.tsx
+++ b/components/DishForm.tsx
@@ -34,7 +34,7 @@ const DishForm: React.FC<Props> = props => {
       setDish(null);
       form.resetFields();
     };
-  }, [dishId, form]);
+  }, [dishId, form, handleDishModal]);
 
   const onFinish = async (values: any) => {
     console.log("values:", values);

--- a/pages/dish.tsx
+++ b/pages/dish.tsx
@@ -135,6 +135,7 @@ const Dish: React.FC = () => {
           dataSource={dishes?.data}
           columns={columns}
           loading={isLoading}
+          pagination={false}
         />
       </Space>
     </Layout>


### PR DESCRIPTION
Issue: When you add a dish and then click to add another dish, the previous dish's information is still there.

Fix: Add handleDishModal to the useEffect dependency array in DishForm.

Other: Remove pagination on the Dish page.